### PR TITLE
Properly ignore ignored fields within repeated fields when ordering ignored

### DIFF
--- a/proto_matcher/compare/compare.py
+++ b/proto_matcher/compare/compare.py
@@ -152,18 +152,23 @@ class MessageDifferencer():
     def _compare_repeated_field(
             self, cmp_args: ProtoFieldComparisonArgs[Iterable]
     ) -> ProtoComparisonResult:
-        as_set_key = lambda x: str(x)
+        expected_list = cmp_args.expected
+        actual_list = cmp_args.actual
         if self._opts.repeated_field_comp == RepeatedFieldComparison.AS_SET:
-            cmp_args.expected.sort(key=as_set_key)
-            cmp_args.actual.sort(key=as_set_key)
+            as_set_key = lambda x: str(x)
+            # Copy before sorting to avoid modifying the original inputs.
+            expected_list = [x for x in expected_list]
+            expected_list.sort(key=as_set_key)
+            actual_list = [x for x in actual_list]
+            actual_list.sort(key=as_set_key)
         return _combine_results([
             self._compare_value(
                 ProtoFieldComparisonArgs(expected=expected,
                                          actual=actual,
                                          field_desc=cmp_args.field_desc,
                                          field_path=cmp_args.field_path))
-            for expected, actual in iter_util.zip_pairs(cmp_args.expected,
-                                                        cmp_args.actual)
+            for expected, actual in iter_util.zip_pairs(expected_list,
+                                                        actual_list)
         ])
 
     def _compare_map(

--- a/proto_matcher/compare/compare_test.py
+++ b/proto_matcher/compare/compare_test.py
@@ -291,7 +291,8 @@ class ProtoCompareTest(unittest.TestCase):
             repeated_field_comp=compare.RepeatedFieldComparison.AS_SET)
         compare.proto_compare(actual, expected, opts=opts)
 
-        self.assertEqual(expected, text_format.Parse(_TEST_PROTO, test_pb2.Foo()))
+        self.assertEqual(
+            expected, text_format.Parse(_TEST_PROTO, test_pb2.Foo()))
         self.assertEqual(actual, text_format.Parse(_TEST_PROTO, test_pb2.Foo()))
 
     def test_ignore_nested_field_with_ignore_repeated_field_order(self):
@@ -329,11 +330,11 @@ class ProtoCompareTest(unittest.TestCase):
         self.assertProtoCompareToBe(
             compare.proto_compare(actual, expected, opts=opts), False)
 
-        # opts = compare.ProtoComparisonOptions(
-        #     repeated_field_comp=compare.RepeatedFieldComparison.AS_SET,
-        #     ignore_field_paths={('bars', 'short_id'), ('bars', 'long_id')})
-        # self.assertProtoCompareToBe(
-        #     compare.proto_compare(actual, expected, opts=opts), True)
+        opts = compare.ProtoComparisonOptions(
+            repeated_field_comp=compare.RepeatedFieldComparison.AS_SET,
+            ignore_field_paths={('bars', 'short_id'), ('bars', 'long_id')})
+        self.assertProtoCompareToBe(
+            compare.proto_compare(actual, expected, opts=opts), True)
 
 
 if __name__ == '__main__':

--- a/proto_matcher/matcher/matcher_test.py
+++ b/proto_matcher/matcher/matcher_test.py
@@ -200,6 +200,48 @@ class ProtoCompareTest(unittest.TestCase):
         assert_that(actual,
                     ignoring_repeated_field_ordering(equals_proto(expected)))
 
+    def test_ignore_nested_field_with_ignore_repeated_field_order(self):
+        expected = test_pb2.Foo()
+        expected.bars.extend([
+            test_pb2.Bar(
+                short_id=1,
+                name='first bar',
+            ),
+            test_pb2.Bar(
+                short_id=2,
+                name='second bar',
+            ),
+        ])
+        actual = test_pb2.Foo()
+        actual.bars.extend([
+            test_pb2.Bar(
+                long_id=20,
+                name='second bar',
+            ),
+            test_pb2.Bar(
+                long_id=10,
+                name='first bar',
+            ),
+        ])
+
+        assert_that(actual, not_(equals_proto(expected)))
+        assert_that(
+            actual,
+            not_(ignoring_repeated_field_ordering(equals_proto(expected))))
+        ignored_fields = {('bars', 'short_id'), ('bars', 'long_id')}
+        assert_that(
+            actual,
+            not_(ignoring_field_paths(ignored_fields, equals_proto(expected))))
+        assert_that(
+            actual,
+            ignoring_repeated_field_ordering(
+                ignoring_field_paths(ignored_fields, equals_proto(expected))))
+        assert_that(
+            actual,
+            ignoring_field_paths(
+                ignored_fields,
+                ignoring_repeated_field_ordering(equals_proto(expected))))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Also avoid modifying input. Previously the comparison code sorted repeated fields when order is ignored, which could cause subsequent comparisons to fail unexpectedly. (This is probably broken for oneof comparisons also, but since I'm going to have to publish my own package anyway, I'll fix that as a follow-up.)