### PR TITLE
Support modern protobuf runtimes that removed FieldDescriptor.label

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,60 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: protobuf ${{ matrix.protobuf || 'latest' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # One representative per protobuf major version, each on a Python it
+        # supports. The empty pin means "latest release", so new majors get
+        # covered here before they get their own pinned entry.
+        include:
+          - protobuf: "3.20.*"
+            python: "3.9"
+          - protobuf: "4.25.*"
+            python: "3.11"
+          - protobuf: "5.29.*"
+            python: "3.12"
+          - protobuf: "6.*"
+            python: "3.13"
+          - protobuf: ""
+            python: "3.x"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          pip install pytest pyhamcrest
+          if [ -n "${{ matrix.protobuf }}" ]; then
+            pip install "protobuf==${{ matrix.protobuf }}"
+          else
+            pip install protobuf
+          fi
+      - name: Install the protoc matching the protobuf runtime
+        # The runtime rejects gencode newer than itself and old runtimes lack
+        # the APIs new gencode calls, so the test proto must be compiled with
+        # the protoc release paired with the installed runtime: pip 3.X.Y maps
+        # to protoc v3.X.Y, and pip MAJOR.MINOR.PATCH maps to protoc
+        # vMINOR.PATCH from 4.x on.
+        run: |
+          PB="$(python -c 'import google.protobuf as pb; print(pb.__version__)')"
+          case "$PB" in
+            3.*) PROTOC="$PB" ;;
+            *) PROTOC="${PB#*.}" ;;
+          esac
+          curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC}/protoc-${PROTOC}-linux-x86_64.zip"
+          unzip -q /tmp/protoc.zip -d "$HOME/protoc"
+          echo "$HOME/protoc/bin" >> "$GITHUB_PATH"
+      - name: Generate test protos
+        run: protoc -I. -I"$HOME/protoc/include" --python_out=. proto_matcher/testdata/test.proto
+      - run: python -m pytest proto_matcher

--- a/proto_matcher/compare/compare.py
+++ b/proto_matcher/compare/compare.py
@@ -138,7 +138,7 @@ class MessageDifferencer():
         cmp_args.actual = getattr(cmp_args.actual, field_name, None)
 
         # Repeated field
-        if cmp_args.field_desc.label == _FieldDescriptor.LABEL_REPEATED:
+        if _is_repeated(cmp_args.field_desc):
             # Map field
             if isinstance(cmp_args.expected, collections.abc.Mapping):
                 return self._compare_map(cmp_args)
@@ -260,6 +260,15 @@ def _combine_results(
         explanation='\n'.join(
             [res.explanation for res in results if res.explanation]),
     )
+
+
+def _is_repeated(field_desc: _FieldDescriptor) -> bool:
+    # Newer protobuf runtimes removed FieldDescriptor.label in favor of the
+    # is_repeated property; older ones (< 4.21) only have label.
+    is_repeated = getattr(field_desc, 'is_repeated', None)
+    if is_repeated is not None:
+        return is_repeated
+    return field_desc.label == _FieldDescriptor.LABEL_REPEATED
 
 
 def _is_message(field_desc: _FieldDescriptor) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="hamcrest_proto",
-    version="0.0.6",
+    version="0.0.7",
     author="mdepinet",
     author_email="",
     description="Hamcrest matchers for protobufs",


### PR DESCRIPTION
## Problem

`proto_compare` (and therefore every matcher: `equals_proto`, `partially`, ...) crashes on current protobuf runtimes:

```
File ".../proto_matcher/compare/compare.py", line 141, in _compare_field
    if cmp_args.field_desc.label == _FieldDescriptor.LABEL_REPEATED:
AttributeError: 'google._upb._message.FieldDescriptor' object has no attribute 'label'
```

The upb runtime deprecated `FieldDescriptor.label` in favor of the `is_repeated` property and has since removed it, so the library is unusable with recent protobuf (reproduced on protobuf 7.35.1 / Python 3.14; this is what pushed us to shim it out of a downstream project).

## Fix

A `_is_repeated` helper that prefers `is_repeated` when the descriptor has it and falls back to `label` otherwise, keeping the existing `protobuf>=3.11.3` floor working. No other removed descriptor APIs are used: `cpp_type`/`enum_type`/`name` all still exist.

Also bumps the version to 0.0.7 so a fixed release can go straight to PyPI — happy to drop that hunk if you version differently.

## CI

Adds a GitHub Actions workflow running the test suite across a matrix of protobuf major versions — one pinned entry per major (`3.20.*`, `4.25.*`, `5.29.*`, `6.*`), each on a Python it supports, plus a floating `latest` entry (7.35.1 today) so future majors get covered before they get a pinned row. Because a runtime rejects gencode newer than itself and old runtimes lack the APIs new gencode calls, each job compiles `testdata/test.proto` with the protoc release paired to its installed runtime (pip `3.X.Y` ↔ protoc `v3.X.Y`; from 4.x on, pip `MAJOR.MINOR.PATCH` ↔ protoc `vMINOR.PATCH`).

## Testing

- All five matrix jobs are green on this branch: 46 tests pass on protobuf 3.20.3, 4.25.9, 5.29.6, 6.33.6, and 7.35.1 — so the `label` fallback for old runtimes is verified in CI, not just reasoned about.
- Exercised end-to-end from a downstream consumer: `partially(equals_proto(...))` against real generated messages matches partially, ignores extra fields, and produces the field-path diff on mismatch.
- The generated `test_pb2.py` is deliberately not committed; CI (like bazel) regenerates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
