### PR TITLE
Publish to PyPI from GitHub releases via Trusted Publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Keeps the SHA-pinned actions in .github/workflows fresh (Dependabot updates
+# the pin and its version comment together).
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: release
     permissions:
       # For PyPI Trusted Publishing (OIDC); no stored credentials.
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Check the release tag matches setup.py's version
         run: |
           VERSION="$(sed -n 's/.*version="\([^"]*\)".*/\1/p' setup.py)"
@@ -19,12 +19,12 @@ jobs:
             echo "setup.py has version $VERSION but the release tag is $GITHUB_REF_NAME" >&2
             exit 1
           fi
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.x"
       - run: pip install build
       - run: python -m build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: dist/
@@ -39,8 +39,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,11 @@ on:
     types: [published]
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: release
     permissions:
-      # For PyPI Trusted Publishing (OIDC); no stored credentials.
-      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Check the release tag matches setup.py's version
@@ -26,4 +24,23 @@ jobs:
           python-version: "3.x"
       - run: pip install build
       - run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  # Publishing is a separate job so no repository-controlled code runs while the
+  # OIDC token for PyPI Trusted Publishing (no stored credentials) is available.
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # For PyPI Trusted Publishing (OIDC); no stored credentials.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check the release tag matches setup.py's version
+        run: |
+          VERSION="$(sed -n 's/.*version="\([^"]*\)".*/\1/p' setup.py)"
+          if [ "$VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "setup.py has version $VERSION but the release tag is $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Publishing a GitHub release now builds the sdist/wheel and uploads it to PyPI via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC — no token or password stored anywhere), after a guard checks the release tag matches `setup.py`'s version (tags here are plain `0.0.6`-style, matching the existing ones).

**One-time setup only you can do**: in the PyPI project settings for `hamcrest-proto` → *Publishing*, add a GitHub trusted publisher with owner `mdepinet`, repository `hamcrest-proto`, workflow `publish.yml`, environment `release`. Until that's registered, the upload step will fail with an OIDC error.

The first real run will be the `0.0.7` release (main already carries the version bump from #5): create a GitHub release with tag `0.0.7` and this workflow does the rest. That run is also the workflow's first live test — the sed version-guard and build steps I verified locally, but the upload leg can only be proven by an actual release.

Replaces the uncommitted `PUBLISHING.md` twine flow as the durable directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
